### PR TITLE
[codex] Return 404 for unknown API routes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 
 from arq import create_pool
 from arq.connections import RedisSettings
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from sqladmin import Admin
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -48,6 +48,14 @@ def create_app() -> FastAPI:
     from src.api.telegram_webhook import router as telegram_router
 
     app.include_router(telegram_router, prefix="/api/v1")
+
+    @app.api_route(
+        "/api/{full_path:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+        include_in_schema=False,
+    )
+    async def api_not_found(full_path: str) -> None:
+        raise HTTPException(status_code=404, detail="Not Found")
 
     # Mount SQLAdmin
     from src.api.admin.auth import authentication_backend

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -118,6 +118,18 @@ async def test_admin_requires_auth(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_unknown_api_routes_do_not_fall_through_to_spa(
+    client: AsyncClient,
+) -> None:
+    """Unknown API paths must fail as API errors, not landing-page HTML."""
+    response = await client.get("/api/v1/admin/bot-rules")
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["detail"] == "Not Found"
+
+
+@pytest.mark.asyncio
 async def test_admin_login_grants_dashboard_and_api_access(client: AsyncClient) -> None:
     """Real SQLAdmin login should authorize /dashboard and /api/v1/admin routes."""
     dashboard_response = await client.get("/dashboard/")


### PR DESCRIPTION
## Summary
- Adds an explicit FastAPI `/api/*` fallback before the landing SPA catch-all.
- Unknown API paths now return JSON `404` instead of landing `index.html` with HTTP `200`.
- Covers the production smoke finding with a regression test.

## Verification
- `uv run pytest tests/test_api_admin.py::test_unknown_api_routes_do_not_fall_through_to_spa -v --tb=short` failed before the fix with `200 == 404`.
- `uv run pytest tests/test_api_admin.py::test_unknown_api_routes_do_not_fall_through_to_spa tests/test_api_admin.py::test_admin_requires_auth tests/test_admin_bot_rules_api.py::test_admin_bot_rules_requires_admin_session tests/test_admin_knowledge_base_api.py::test_admin_knowledge_base_requires_admin_session -v --tb=short`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev mypy src/`
- `env DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH:-/opt/homebrew/lib}" uv run pytest tests/ -v --tb=short` -> 936 passed, 16 skipped
- `scripts/orchestration/run_process_verification.sh`
