### PR TITLE
[codex] Remove external font dependency from admin

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -7,9 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Treejar Noor AI — Admin Dashboard with real-time analytics and KPI metrics" />
     <title>Noor Dashboard — Treejar Admin</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
 </head>
 
 <body>

--- a/tests/test_admin_dashboard_frontend.py
+++ b/tests/test_admin_dashboard_frontend.py
@@ -29,6 +29,15 @@ def test_crm_admin_static_contract() -> None:
     assert result.returncode == 0, result.stderr or result.stdout
 
 
+def test_admin_dashboard_uses_no_external_font_hosts() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    index_html = repo_root / "frontend" / "admin" / "index.html"
+    source = index_html.read_text(encoding="utf-8")
+
+    assert "fonts.googleapis.com" not in source
+    assert "fonts.gstatic.com" not in source
+
+
 def test_operator_center_review_message_handles_refresh_failure_after_success() -> None:
     result = _run_frontend_regression("operator_center_review_message_regression.mjs")
 


### PR DESCRIPTION
## Summary
- Removes the external Google Fonts stylesheet/preconnects from the admin dashboard HTML.
- Keeps the existing system font stack, avoiding production CSP violations and external font requests.
- Adds a regression test that blocks `fonts.googleapis.com` / `fonts.gstatic.com` from `frontend/admin/index.html`.

## Verification
- Red: `uv run pytest tests/test_admin_dashboard_frontend.py::test_admin_dashboard_uses_no_external_font_hosts -v --tb=short` failed before the fix on `fonts.googleapis.com`.
- Green: same test passed after the fix.
- `npm --prefix frontend/admin run build`
- `npm --prefix frontend/admin run lint`
- `for f in frontend/admin/tests/*.mjs; do node "$f" || exit $?; done`
- `uv run pytest tests/test_admin_dashboard_frontend.py -v --tb=short` -> 10 passed
- `scripts/orchestration/run_process_verification.sh`
