### PR TITLE
fix(admin): redirect login to CRM dashboard

### DIFF
--- a/src/api/admin/dashboard_redirect_admin.py
+++ b/src/api/admin/dashboard_redirect_admin.py
@@ -1,0 +1,28 @@
+from sqladmin import Admin
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+
+class DashboardRedirectAdmin(Admin):
+    """SQLAdmin wrapper that lands normal admins in the CRM dashboard."""
+
+    async def login(self, request: Request) -> Response:
+        if self.authentication_backend is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Authentication backend not configured.",
+            )
+
+        context: dict[str, str] = {}
+        if request.method == "GET":
+            return await self.templates.TemplateResponse(request, "sqladmin/login.html")
+
+        ok = await self.authentication_backend.login(request)
+        if not ok:
+            context["error"] = "Invalid credentials."
+            return await self.templates.TemplateResponse(
+                request, "sqladmin/login.html", context, status_code=400
+            )
+
+        return RedirectResponse(url="/dashboard/", status_code=302)

--- a/src/main.py
+++ b/src/main.py
@@ -6,9 +6,9 @@ from contextlib import asynccontextmanager
 from arq import create_pool
 from arq.connections import RedisSettings
 from fastapi import FastAPI, HTTPException, Request
-from sqladmin import Admin
 from starlette.middleware.sessions import SessionMiddleware
 
+from src.api.admin.dashboard_redirect_admin import DashboardRedirectAdmin
 from src.api.v1.admin import require_admin_session
 from src.core.config import settings
 from src.core.database import engine
@@ -60,7 +60,7 @@ def create_app() -> FastAPI:
     # Mount SQLAdmin
     from src.api.admin.auth import authentication_backend
 
-    admin = Admin(
+    admin = DashboardRedirectAdmin(
         app,
         engine,
         title="Treejar Admin",

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -146,6 +146,7 @@ async def test_admin_login_grants_dashboard_and_api_access(client: AsyncClient) 
         },
     )
     assert login_response.status_code in (200, 302, 303)
+    assert login_response.headers["location"].endswith("/dashboard/")
 
     admin_response = await client.get("/admin/")
     assert admin_response.status_code == 200


### PR DESCRIPTION
## Summary
- route successful SQLAdmin form login to the CRM dashboard at /dashboard/
- keep /admin/ reachable as the technical SQLAdmin fallback after login
- add a regression assertion for the login redirect target

## Root cause
SQLAdmin redirects successful POST /admin/login to its own admin:index (/admin/) by default, so owners land in the old raw database-style admin instead of the CRM workspace.

## Verification
- LOGFIRE_IGNORE_NO_CONFIG=1 OPENROUTER_API_KEY=test-key WAZZUP_API_KEY=fake-wazzup-key WAZZUP_API_URL=http://fake-wazzup-url uv run pytest tests/test_api_admin.py::test_admin_login_grants_dashboard_and_api_access -q
- LOGFIRE_IGNORE_NO_CONFIG=1 OPENROUTER_API_KEY=test-key WAZZUP_API_KEY=fake-wazzup-key WAZZUP_API_URL=http://fake-wazzup-url uv run pytest tests/test_api_admin.py tests/test_api_admin_auth.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy src/
- LOGFIRE_IGNORE_NO_CONFIG=1 OPENROUTER_API_KEY=test-key WAZZUP_API_KEY=fake-wazzup-key WAZZUP_API_URL=http://fake-wazzup-url env DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH:-/opt/homebrew/lib}" uv run pytest tests/ -v --tb=short
- scripts/orchestration/run_process_verification.sh

No deploy or production mutation.