### PR TITLE
fix(admin): repair light theme chart contrast

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8" />

--- a/frontend/admin/src/components/charts/ConversationsChart.tsx
+++ b/frontend/admin/src/components/charts/ConversationsChart.tsx
@@ -8,7 +8,16 @@ import {
     XAxis,
     YAxis,
 } from 'recharts';
-import { CHART_AXIS_FONT_SIZE, CHART_AXIS_STROKE, CHART_GRID_STROKE, CHART_TOOLTIP_STYLE } from './chartTheme';
+import {
+    CHART_AXIS_FONT_SIZE,
+    CHART_AXIS_STROKE,
+    CHART_CARD_CLASS,
+    CHART_EMPTY_CLASS,
+    CHART_GRID_STROKE,
+    CHART_META_CLASS,
+    CHART_TITLE_CLASS,
+    CHART_TOOLTIP_STYLE,
+} from './chartTheme';
 import type { TimeseriesPoint } from '@/types/metrics';
 
 interface ConversationsChartProps {
@@ -33,12 +42,12 @@ export default function ConversationsChart({ points, totalConversations }: Conve
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.3 }}
-            className="rounded-2xl bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-xl border border-white/[0.08] p-6"
+            className={CHART_CARD_CLASS}
         >
             <div className="mb-4 flex items-center justify-between">
                 <div>
-                    <h3 className="text-lg font-semibold text-slate-200">Conversations</h3>
-                    <p className="text-sm text-slate-500">New vs Returning • Total: {totalConversations}</p>
+                    <h3 className={CHART_TITLE_CLASS}>Conversations</h3>
+                    <p className={CHART_META_CLASS}>New vs Returning • Total: {totalConversations}</p>
                 </div>
             </div>
             {data.length > 0 ? (
@@ -69,7 +78,7 @@ export default function ConversationsChart({ points, totalConversations }: Conve
                     </LineChart>
                 </ResponsiveContainer>
             ) : (
-                <div className="flex items-center justify-center h-[280px] text-slate-600 text-sm">
+                <div className={`${CHART_EMPTY_CLASS} h-[280px]`}>
                     No conversation data for this period
                 </div>
             )}

--- a/frontend/admin/src/components/charts/SalesBarChart.tsx
+++ b/frontend/admin/src/components/charts/SalesBarChart.tsx
@@ -1,6 +1,14 @@
 import { motion } from 'framer-motion';
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { CHART_AXIS_FONT_SIZE, CHART_AXIS_STROKE, CHART_GRID_STROKE, CHART_TOOLTIP_STYLE } from './chartTheme';
+import {
+    CHART_AXIS_FONT_SIZE,
+    CHART_AXIS_STROKE,
+    CHART_CARD_CLASS,
+    CHART_GRID_STROKE,
+    CHART_META_CLASS,
+    CHART_TITLE_CLASS,
+    CHART_TOOLTIP_STYLE,
+} from './chartTheme';
 
 interface SalesBarChartProps {
     noorSales: { count: number; amount: number };
@@ -26,12 +34,12 @@ export default function SalesBarChart({
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.5 }}
-            className="rounded-2xl bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-xl border border-white/[0.08] p-6"
+            className={CHART_CARD_CLASS}
         >
             <div className="mb-4 flex items-center justify-between">
                 <div>
-                    <h3 className="text-lg font-semibold text-slate-200">Sales & Escalation</h3>
-                    <p className="text-sm text-slate-500">Conversion Rate: {conversionRate}%</p>
+                    <h3 className={CHART_TITLE_CLASS}>Sales & Escalation</h3>
+                    <p className={CHART_META_CLASS}>Conversion Rate: {conversionRate}%</p>
                 </div>
             </div>
             <ResponsiveContainer width="100%" height={280}>

--- a/frontend/admin/src/components/charts/SegmentPieChart.tsx
+++ b/frontend/admin/src/components/charts/SegmentPieChart.tsx
@@ -1,6 +1,13 @@
 import { motion } from 'framer-motion';
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
-import { CHART_TOOLTIP_STYLE } from './chartTheme';
+import {
+    CHART_CARD_CLASS,
+    CHART_EMPTY_CLASS,
+    CHART_LEGEND_STYLE,
+    CHART_SUBTITLE_CLASS,
+    CHART_TITLE_CLASS,
+    CHART_TOOLTIP_STYLE,
+} from './chartTheme';
 
 interface SegmentPieChartProps {
     byLanguage: Record<string, number>;
@@ -36,13 +43,13 @@ export default function SegmentPieChart({ byLanguage, targetVsNontarget }: Segme
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.4 }}
-            className="rounded-2xl bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-xl border border-white/[0.08] p-6"
+            className={CHART_CARD_CLASS}
         >
-            <h3 className="text-lg font-semibold text-slate-200 mb-4">Classification</h3>
+            <h3 className={`${CHART_TITLE_CLASS} mb-4`}>Classification</h3>
             <div className="grid grid-cols-2 gap-4">
                 {/* Language donut */}
                 <div>
-                    <p className="text-xs text-slate-500 text-center mb-2">By Language</p>
+                    <p className={CHART_SUBTITLE_CLASS}>By Language</p>
                     {hasLangData ? (
                         <ResponsiveContainer width="100%" height={200}>
                             <PieChart>
@@ -64,13 +71,13 @@ export default function SegmentPieChart({ byLanguage, targetVsNontarget }: Segme
                             </PieChart>
                         </ResponsiveContainer>
                     ) : (
-                        <div className="flex items-center justify-center h-[200px] text-slate-600 text-sm">No data</div>
+                        <div className={`${CHART_EMPTY_CLASS} h-[200px]`}>No data</div>
                     )}
                 </div>
 
                 {/* Target vs non-target donut */}
                 <div>
-                    <p className="text-xs text-slate-500 text-center mb-2">Target vs Non-target</p>
+                    <p className={CHART_SUBTITLE_CLASS}>Target vs Non-target</p>
                     {hasTargetData ? (
                         <ResponsiveContainer width="100%" height={200}>
                             <PieChart>
@@ -89,11 +96,11 @@ export default function SegmentPieChart({ byLanguage, targetVsNontarget }: Segme
                                     ))}
                                 </Pie>
                                 <Tooltip contentStyle={CHART_TOOLTIP_STYLE} />
-                                <Legend wrapperStyle={{ color: '#94a3b8', fontSize: '12px' }} />
+                                <Legend wrapperStyle={CHART_LEGEND_STYLE} />
                             </PieChart>
                         </ResponsiveContainer>
                     ) : (
-                        <div className="flex items-center justify-center h-[200px] text-slate-600 text-sm">No data</div>
+                        <div className={`${CHART_EMPTY_CLASS} h-[200px]`}>No data</div>
                     )}
                 </div>
             </div>

--- a/frontend/admin/src/components/charts/chartTheme.ts
+++ b/frontend/admin/src/components/charts/chartTheme.ts
@@ -1,13 +1,24 @@
-/** Shared chart theme constants for dark dashboard. */
+/** Shared chart tokens for the CRM dashboard light and dark themes. */
 
 export const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-    backgroundColor: '#1e293b',
-    border: '1px solid rgba(255,255,255,0.1)',
+    backgroundColor: 'var(--admin-chart-tooltip-bg)',
+    border: '1px solid var(--admin-chart-tooltip-border)',
     borderRadius: '12px',
-    color: '#e2e8f0',
+    color: 'var(--admin-chart-tooltip-text)',
     fontSize: '13px',
+    boxShadow: 'var(--admin-chart-shadow)',
 };
 
-export const CHART_GRID_STROKE = '#1e293b';
-export const CHART_AXIS_STROKE = '#64748b';
+export const CHART_CARD_CLASS =
+    'admin-chart-card rounded-2xl p-6';
+export const CHART_TITLE_CLASS = 'text-lg font-semibold text-[var(--admin-chart-title)]';
+export const CHART_META_CLASS = 'text-sm text-[var(--admin-chart-muted)]';
+export const CHART_SUBTITLE_CLASS = 'mb-2 text-center text-xs text-[var(--admin-chart-muted)]';
+export const CHART_EMPTY_CLASS = 'flex items-center justify-center text-sm text-[var(--admin-chart-empty)]';
+export const CHART_LEGEND_STYLE: React.CSSProperties = {
+    color: 'var(--admin-chart-muted)',
+    fontSize: '12px',
+};
+export const CHART_GRID_STROKE = 'var(--admin-chart-grid)';
+export const CHART_AXIS_STROKE = 'var(--admin-chart-axis)';
 export const CHART_AXIS_FONT_SIZE = 12;

--- a/frontend/admin/src/index.css
+++ b/frontend/admin/src/index.css
@@ -4,6 +4,31 @@
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --admin-chart-surface: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  --admin-chart-border: rgba(15, 23, 42, 0.12);
+  --admin-chart-title: #0f172a;
+  --admin-chart-muted: #475569;
+  --admin-chart-empty: #64748b;
+  --admin-chart-grid: rgba(30, 41, 59, 0.16);
+  --admin-chart-axis: #64748b;
+  --admin-chart-tooltip-bg: #ffffff;
+  --admin-chart-tooltip-border: rgba(15, 23, 42, 0.16);
+  --admin-chart-tooltip-text: #0f172a;
+  --admin-chart-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+}
+
+:where(.dark, .dark *) {
+  --admin-chart-surface: linear-gradient(135deg, rgba(30, 41, 59, 0.58) 0%, rgba(15, 23, 42, 0.58) 100%);
+  --admin-chart-border: rgba(255, 255, 255, 0.1);
+  --admin-chart-title: #e2e8f0;
+  --admin-chart-muted: #94a3b8;
+  --admin-chart-empty: #64748b;
+  --admin-chart-grid: rgba(148, 163, 184, 0.22);
+  --admin-chart-axis: #94a3b8;
+  --admin-chart-tooltip-bg: #1e293b;
+  --admin-chart-tooltip-border: rgba(255, 255, 255, 0.12);
+  --admin-chart-tooltip-text: #e2e8f0;
+  --admin-chart-shadow: none;
 }
 
 body {
@@ -15,4 +40,10 @@ body {
 
 #root {
   min-height: 100vh;
+}
+
+.admin-chart-card {
+  border: 1px solid var(--admin-chart-border);
+  background: var(--admin-chart-surface);
+  box-shadow: var(--admin-chart-shadow);
 }

--- a/frontend/admin/tests/light_theme_chart_regression.mjs
+++ b/frontend/admin/tests/light_theme_chart_regression.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(scriptDir, '..');
+
+const indexCss = await readFile(path.join(frontendRoot, 'src', 'index.css'), 'utf8');
+const indexHtml = await readFile(path.join(frontendRoot, 'index.html'), 'utf8');
+const chartTheme = await readFile(path.join(frontendRoot, 'src', 'components', 'charts', 'chartTheme.ts'), 'utf8');
+const chartFiles = [
+    'ConversationsChart.tsx',
+    'SegmentPieChart.tsx',
+    'SalesBarChart.tsx',
+];
+
+for (const token of [
+    '--admin-chart-surface',
+    '--admin-chart-border',
+    '--admin-chart-title',
+    '--admin-chart-muted',
+    '--admin-chart-grid',
+    '--admin-chart-axis',
+    '--admin-chart-tooltip-bg',
+]) {
+    assert.match(indexCss, new RegExp(token), `Light theme should define ${token}`);
+}
+
+assert.match(indexCss, /:where\(\.dark, \.dark \*\)/, 'Dark overrides should be opt-in through the dark class');
+assert.match(indexCss, /\.admin-chart-card/, 'Chart card surface should be rendered by a real CSS class');
+assert.doesNotMatch(indexHtml, /<html[^>]*class="dark"/, 'Light theme should not be disabled by a hard-coded dark class');
+assert.match(chartTheme, /var\(--admin-chart-grid\)/, 'Grid color should come from theme tokens');
+assert.match(chartTheme, /var\(--admin-chart-axis\)/, 'Axis color should come from theme tokens');
+assert.match(chartTheme, /var\(--admin-chart-tooltip-bg\)/, 'Tooltip background should come from theme tokens');
+assert.match(chartTheme, /CHART_CARD_CLASS/, 'Chart panels should share a theme-aware card class');
+assert.match(chartTheme, /admin-chart-card/, 'Chart panels should use the real CSS card class');
+
+for (const file of chartFiles) {
+    const source = await readFile(path.join(frontendRoot, 'src', 'components', 'charts', file), 'utf8');
+    assert.match(source, /CHART_CARD_CLASS/, `${file} should use the shared theme-aware chart card class`);
+    assert.doesNotMatch(source, /from-slate-800\/50|to-slate-900\/50/, `${file} should not force dark chart panels in light mode`);
+    assert.doesNotMatch(source, /border-white\/\[0\.08\]/, `${file} should not use dark-only borders in light mode`);
+    assert.doesNotMatch(source, /text-slate-200/, `${file} should not force dark-title text in light mode`);
+}

--- a/tests/test_admin_dashboard_frontend.py
+++ b/tests/test_admin_dashboard_frontend.py
@@ -38,6 +38,12 @@ def test_admin_dashboard_uses_no_external_font_hosts() -> None:
     assert "fonts.gstatic.com" not in source
 
 
+def test_admin_light_theme_charts_use_readable_tokens() -> None:
+    result = _run_frontend_regression("light_theme_chart_regression.mjs")
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_operator_center_review_message_handles_refresh_failure_after_success() -> None:
     result = _run_frontend_regression("operator_center_review_message_regression.mjs")
 


### PR DESCRIPTION
## Summary
- remove the hard-coded dark class from the admin HTML shell so the light theme can actually render as light
- move overview chart surfaces, text, grid, axes, legends, and tooltips to theme-aware CSS tokens
- replace hard-coded dark chart panel classes in the overview charts and add a light-theme regression script

## Context7
- Tailwind CSS v4 docs: used current guidance for theme CSS variables and dark variant/class overrides
- Recharts docs: used current examples for explicit grid/axis/tooltip/legend styling props

## Verification
- node frontend/admin/tests/light_theme_chart_regression.mjs
- for f in frontend/admin/tests/*.mjs; do node "" || exit 1; done
- npm --prefix frontend/admin run lint
- npm --prefix frontend/admin run build
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy src/
- LOGFIRE_IGNORE_NO_CONFIG=1 OPENROUTER_API_KEY=test-key WAZZUP_API_KEY=fake-wazzup-key WAZZUP_API_URL=http://fake-wazzup-url env DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH:-/opt/homebrew/lib}" uv run pytest tests/ -v --tb=short
- scripts/orchestration/run_process_verification.sh
- local Playwright smoke with mocked admin metrics: light Overview chart card rendered white/slate-50 gradient, readable title, light border, light grid

No deploy or production mutation.